### PR TITLE
Shoppig bag cart page

### DIFF
--- a/Templates/Cart.html
+++ b/Templates/Cart.html
@@ -7,7 +7,7 @@
 <br><br/>
 
 <div>
-    {{ color }}  {{ size }}
+    {{ color }} {{ size }}
 
 
 </div>


### PR DESCRIPTION
add to shopping bag button takes to cart page. why it doesn't show the selected color and size? need help. 
